### PR TITLE
Pin Aider to a commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,6 +13,7 @@
       "original": {
         "owner": "paul-gauthier",
         "repo": "aider",
+        "rev": "5ae96231ad5be9158e35bb916b3d276f3139d18a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,8 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     aider-input = {
-      url = "github:paul-gauthier/aider";
+      # v0.47.0 is commit 5ae96231
+      url = "github:paul-gauthier/aider/5ae96231ad5be9158e35bb916b3d276f3139d18a";
       flake = false;
     };
     grep-ast = {


### PR DESCRIPTION
Otherwise this just always installs the current `main` which soon won't be in sync with the version number in `aider = buildPythonPackage`.

I guess if this is intended as a private flake, it's ok to let the version number get out of sync. But if others use it too, it will be confusing to have an arbitrary version number for the current `main` commit.

Instead of a commit, a version number can then also be used:
```nix
{
  description = "A flake for aider";

  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    flake-parts.url = "github:hercules-ci/flake-parts";
    aider-input = {
      url = "github:paul-gauthier/aider/v0.47.1";
      flake = false;
    };
  };

  outputs = <...>:
      # <...>
        aider = pyPkgs.buildPythonPackage {
          pname = "aider";
          version = "0.47.1";
```