### PR TITLE
Update to aider 0.47.1 (rebase after #3, #4 and #5)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,16 @@
     "aider-input": {
       "flake": false,
       "locked": {
-        "lastModified": 1721381381,
-        "narHash": "sha256-Rf8Y/zoWMClljBzTl3J0ugLpeh5tK6mc2ovSEmGRP30=",
+        "lastModified": 1722457300,
+        "narHash": "sha256-PlkC88/WN4O3QdFGjBEVkl7ateqIS/PRADAK00kXfHU=",
         "owner": "paul-gauthier",
         "repo": "aider",
-        "rev": "5ae96231ad5be9158e35bb916b3d276f3139d18a",
+        "rev": "5f82c19f594d9b629d4a10571e69f31388e3e909",
         "type": "github"
       },
       "original": {
         "owner": "paul-gauthier",
+        "ref": "v0.47.1",
         "repo": "aider",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     aider-input = {
-      url = "github:paul-gauthier/aider";
+      url = "github:paul-gauthier/aider/v0.47.1";
       flake = false;
     };
     grep-ast = {
@@ -26,7 +26,7 @@
         pyPkgs = pkgs.python312Packages;
         aider = pyPkgs.buildPythonPackage {
           pname = "aider";
-          version = "0.47.0";
+          version = "0.47.1";
           src = aider-input;
           doCheck = false;
           propagatedBuildInputs = with pyPkgs; [
@@ -62,7 +62,7 @@
         };
         grep-ast = pyPkgs.buildPythonPackage {
           pname = "grep-ast";
-          version = "0.2.4";
+          version = "0.2.4";  # TODO: update to 0.3.3 after rebase
           src = fetchGit {
             url = "https://github.com/paul-gauthier/grep-ast";
             rev = "4adb83e164f31c3a9ae364de8a7b14b9481aca60";
@@ -76,7 +76,7 @@
         };
         streamlit = pyPkgs.buildPythonPackage {
           pname = "streamlit";
-          version = "1.2.0";
+          version = "1.2.0";  # TODO: update to 1.37.0 after rebase
           format = "wheel";
           src = ./streamlit-1.34.0-py2.py3-none-any.whl;
           propagatedBuildInputs = with pyPkgs; [blinker tornado];


### PR DESCRIPTION
NOTE: this needs to be rebased after #3, #4 and #5 have been merged. Version numbers of `grep-ast` and `streamlit` then need to be updated as per the TODO comments, and `flake.lock` needs to be regenerated.