### PR TITLE
Add a default development shell to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,13 @@
           propagatedBuildInputs = with pyPkgs; [tree-sitter];
           doCheck = false;
         };
-      in {packages = {default = aider;};};
+      in {
+        packages = {default = aider;};
+        devShells.default = pkgs.mkShell {
+          packages = [
+            (pkgs.python312.withPackages (ps: [aider]))
+          ];
+        };
+      };
     };
 }


### PR DESCRIPTION
This allows you to do:
```bash
nix develop .
```
and get to a shell where you can e.g.:
```
$ python
Python 3.12.4 (main, Jun  6 2024, 18:26:44) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import aider
>>> 

$ aider
Aider v0.47.1
Models: openrouter/anthropic/claude-3.5-sonnet with diff edit format, weak model openrouter/anthropic/claude-3-haiku-20240307
Git repo: .git with 3 files
Repo-map: using 1024 tokens
Use /help <question> for help, run "aider --help" to see cmd line args
───────────────────────────────────────────
>  
```